### PR TITLE
Update for Prometheus 0.16.0

### DIFF
--- a/prometheus/prometheus.yml.template
+++ b/prometheus/prometheus.yml.template
@@ -4,7 +4,7 @@
 global:
   scrape_interval: 5s
   evaluation_interval: 5s
-  labels:
+  external_labels:
     monitor: stackengine-blog-metrics
 
 rule_files:


### PR DESCRIPTION
`labels` has been renamed to `external_labels`
